### PR TITLE
Functions are also not primitives

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,6 @@ function getPrototypeOf(obj) {
 
 function isPrimitive(item) {
   return (
-    item === null || typeof item !== 'object'
+    item === null || (typeof item !== 'object' && typeof item !== 'function')
   )
 }

--- a/protochain.js
+++ b/protochain.js
@@ -21,6 +21,6 @@ function getPrototypeOf(obj) {
 }
 
 function isPrimitive(item) {
-  return item === null || typeof item !== "object";
+  return item === null || typeof item !== "object" && typeof item !== "function";
 }
 

--- a/test.js
+++ b/test.js
@@ -63,6 +63,12 @@ test('protochain', t => {
       strictEqualArray(t, protochain(new FancyPerson()), [FancyPerson.prototype, Person.prototype, Object.prototype])
       t.end()
     })
+    t.test('functions', t => {
+      class Foo extends Function {}
+      class Bar extends Foo {}
+      strictEqualArray(t, protochain(new Bar()), [Bar.prototype, Foo.prototype, Function.prototype, Object.prototype])
+      t.end()
+    })
   })
 
   // new native types which may not be supported


### PR DESCRIPTION
I thought I'd found a bug, so I wrote a test. Turns out there's no bug! However, you are unnecessarily wrapping functions in `Object`. Even though that's _almost_ a no-op, I figured the correctness fix would be welcome.
